### PR TITLE
Use `got`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,6 @@
 {
-  "presets": ["es2015-node4"],
+  "presets": [
+    ["es2015", { "loose": true }]
+  ],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015"],
+  "presets": ["es2015-node4"],
   "plugins": ["transform-object-rest-spread"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - '0.12'
-  - '4'
-  - '6'
-  - '7'
+  - "4"
+  - "6"
+  - "7"

--- a/README.md
+++ b/README.md
@@ -10,89 +10,81 @@ Logs into plug.dj using a email address and password.
 ```javascript
 const plugLogin = require('plug-login')
 
-plugLogin('my-plug-email@example.com', 'hunter2', (err, result) => {
-  if (err) throw up
-  else     rejoice() // can now do things with result.jar
-})
-
-// with custom request options
-let jar = request.jar()
-plugLogin(
-  'admin@plug.dj', 'hunter3',
-  { jar: jar, headers: { 'user-agent': 'third party app™' } },
-  (err, result) => {
-    if (err) throw err
-    console.log(result.body)
-  }
-)
-
-// "logging in" as a guest
-plugLogin.guest({ authToken: true }, (err, result) => {
-  if (err) throw err
-  else     console.log(result.token)
-})
+plugLogin('my-plug-email@example.com', 'hunter2')
+  .then(rejoice)
+  .catch(() => {
+    // Login failed
+  })
 ```
 
 ## API
 
-### plugLogin(email, password, opts={}, cb)
-### plugLogin.user(email, password, opts={}, cb)
+<a id="pluglogin-user"></a>
+### plugLogin(email, password, opts={})
+### plugLogin.user(email, password, opts={})
 
 Logs in to plug.dj using the given email address and password. You can
 optionally pass options in the third parameter.
 
-`opts` can take some additional. Pass `{ authToken: true }` to also generate a
-WebSocket authentication token. (See below.) Other properties are passed
-straight to [`request`](https://github.com/request/request). A useful one is
-`jar`, which will tell `request` to use an existing cookie jar instead of
-creating a new one.
+Pass `{ authToken: true }` in the options `opts` to also generate a WebSocket
+authentication token. (See below.) Other properties are passed through to
+[`got`](https://github.com/sindresorhus/got).
 
-`cb` is a node-style `(err, result)` callback. `result` is an object with two
-properties, `{ body, jar, token }`, where `body` is plug.dj's login response,
-`jar` is the cookie jar used in the login process, and `token` is the auth token
-(if you asked for one). You can then use the cookie jar in subsequent requests
-so plug.dj will recognise you, and you can use the auth token to set up a
+Returns a promise. The promise resolves with an object with the properties,
+`{ body, session, cookie, token }`, where `body` is plug.dj's login response,
+`session` is the session token, `cookie` is a cookie string with the session
+token filled in, and `token` is the auth token (if you asked for one). You can
+then use the cookie string for `Cookie:` headers in subsequent requests so
+plug.dj will recognise you, and you can use the auth token to set up a
 connection to the plug.dj WebSocket server.
 
-```javascript
-request('https://plug.dj/_/users/me', { json: true, jar: result.jar },
-        (e, {}, body) => { /* `body` contains your user info! */ })
+Using the cookie string with the `got` library:
 
-// Easy WebSocket connection setup using "plug-socket"
-let socket = require('plug-socket')(result.token)
+```javascript
+const got = require('got')
+plugLogin('got@example.com', 'got-is-small-and-good').then((result) => {
+  return got('https://plug.dj/_/users/me', {
+    json: true,
+    headers: { cookie: result.cookie }
+  })
+}).then((response) => {
+  console.log('logged in as', response.body.data[0])
+})
 ```
 
-This method is also available as `plugLogin.user`, with the same
-parameters.
+Using the cookie string with the `request` library:
 
-### plugLogin(opts={}, cb)
-### plugLogin.guest(opts={}, cb)
+```javascript
+const request = require('request')
+let jar = request.jar()
+plugLogin('admin@plug.dj', 'hunter3').then((result) => {
+  // Store it in a jar for the correct domain.
+  jar.setCookie(result.cookie, 'https://plug.dj/')
+  request('https://plug.dj/_/users/me', { jar: jar, json: true }, (err, response) => {
+    console.log('logged in as', response.body.data[0])
+  })
+})
+```
+
+<a id="pluglogin-guest"></a>
+### plugLogin(opts={})
+### plugLogin.guest(opts={})
 
 Gets a plug.dj session cookie and, optionally, WebSocket authentication token
 as a guest user.
 
 `opts` takes the same options as user-style `plugLogin()`.
 
-`cb` is a node-style `(err, result)` callback. `result` is similar to what is
-returned by `plugLogin()`, minus the `body` property.
-
-This method is also available as `plugLogin.guest`, with the same
-parameters.
-
-### plugLogin.getAuthToken(jar, cb)
-
-You can use the `getAuthToken` method separately, for example if you still have
-the cookie jar used for the previous login lying around. Pass the cookie jar to
-`getAuthToken(jar)` and you'll get a shiny new auth token for the plug.dj socket
-server.
+Returns a promise that resolves with an object with the properties,
+`{ session, cookie, token }`. See [plugLogin.user](#pluglogin-user) for what
+those properties mean.
 
 ```javascript
-function reconnectToSocketServer() {
-  plugLogin.getAuthToken(jarUsedForPreviousLogin, (e, token) => {
-    if (e) throw e
-    socket = require('plug-socket')(token)
-  })
-}
+// "logging in" as a guest
+plugLogin.guest({ authToken: true }).then((result) => {
+  // result.token contains an authentication token for the plug.dj WebSocket.
+  require('plug-socket')(result.token)
+})
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -12,13 +12,16 @@
   "repository": "goto-bus-stop/plug-login",
   "bugs": "https://github.com/goto-bus-stop/plug-login/issues",
   "author": "René Kooi <rene@kooi.me>",
+  "engines": {
+    "node": ">= 0.12"
+  },
   "dependencies": {
     "request": "2.x"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
-    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-es2015-node4": "^2.0.3",
     "babel-register": "^6.5.0",
     "mocha": "^3.0.2",
     "standard": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
-    "babel-preset-es2015-node4": "^2.1.0",
+    "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.5.0",
     "mocha": "^3.0.2",
     "standard": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -16,12 +16,14 @@
     "node": ">= 0.12"
   },
   "dependencies": {
-    "request": "2.x"
+    "cookie": "^0.3.1",
+    "got": "^6.5.0",
+    "promise-props": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-plugin-transform-object-rest-spread": "^6.5.0",
-    "babel-preset-es2015-node4": "^2.0.3",
+    "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.5.0",
     "mocha": "^3.0.2",
     "standard": "^8.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ function getAuthToken (opts) {
     json: true
   })).then(({ body }) => {
     if (body.status !== 'ok') {
-     throw error(body.status, body.data[0])
+      throw error(body.status, body.data[0])
     }
     return body.data[0]
   })

--- a/test/test.js
+++ b/test/test.js
@@ -29,19 +29,19 @@ describe('plug-login', function () {
   const INVALID_PASSWORD = 'not_the_password'
   it('cannot login with invalid credentials', () =>
     login(INVALID_EMAIL, INVALID_PASSWORD, { host }).then(fail, (result) => {
-      eq(result.response.body.status, 'badLogin')
+      ok(result)
     })
   )
 
   it('can login with valid credentials', () =>
     login(args.email, args.password, { host }).then((result) => {
-      eq(result.body.status, 'ok')
+      ok(result.session)
     })
   )
 
   it('returns a cookie string that can be used for authenticated requests', () =>
     login(args.email, args.password, { host }).then((result) => {
-      eq(result.body.status, 'ok')
+      ok(result.session)
       return got(`${host}/_/users/me`, {
         headers: { cookie: result.cookie },
         json: true
@@ -53,7 +53,7 @@ describe('plug-login', function () {
 
   it('can optionally retrieve an auth token', () =>
     login(args.email, args.password, { host, authToken: true }).then((result) => {
-      eq(result.body.status, 'ok')
+      ok(result.session)
       eq(typeof result.token, 'string')
     })
   )

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 /* global describe, it, before */
-import request from 'request'
-import { strictEqual as eq, ok } from 'assert'
+import got from 'got'
+import { strictEqual as eq, fail, ok } from 'assert'
 import login from '../src'
 
 const host = process.env.PLUG_LOGIN_HOST || 'https://plug.dj'
@@ -9,17 +9,13 @@ describe('plug-login', function () {
   this.timeout(30000)
 
   // Check that plug.dj is reachable.
-  before((done) => {
-    request(host, (e, _, body) => {
-      if (e) {
-        throw e
-      }
-      if (body.indexOf('<title>maintenance') !== -1) {
+  before(() =>
+    got(host).then((res) => {
+      if (res.body.indexOf('<title>maintenance') !== -1) {
         throw new Error('plug.dj is currently in maintenance mode.')
       }
-      done()
     })
-  })
+  )
 
   ok(process.env.PLUG_LOGIN_NAME, 'pass your test email in the PLUG_LOGIN_NAME env var')
   ok(process.env.PLUG_LOGIN_PASS, 'pass your test password in the PLUG_LOGIN_PASS env var')
@@ -31,62 +27,48 @@ describe('plug-login', function () {
 
   const INVALID_EMAIL = 'invalid-email@invalid-domain.com'
   const INVALID_PASSWORD = 'not_the_password'
-  it('cannot login with invalid credentials', done => {
-    login(INVALID_EMAIL, INVALID_PASSWORD, { host }, (e, result) => {
-      if (e) throw e
-      eq(result.body.status, 'badLogin')
-      done()
+  it('cannot login with invalid credentials', () =>
+    login(INVALID_EMAIL, INVALID_PASSWORD, { host }).then(fail, (result) => {
+      eq(result.response.body.status, 'badLogin')
     })
-  })
+  )
 
-  it('can login with valid credentials', done => {
-    login(args.email, args.password, { host }, (e, result) => {
-      if (e) throw e
+  it('can login with valid credentials', () =>
+    login(args.email, args.password, { host }).then((result) => {
       eq(result.body.status, 'ok')
-      done()
     })
-  })
+  )
 
-  it('returns a usable cookie jar', function (done) {
-    login(args.email, args.password, { host }, (e, result) => {
-      if (e) throw e
+  it('returns a cookie string that can be used for authenticated requests', () =>
+    login(args.email, args.password, { host }).then((result) => {
       eq(result.body.status, 'ok')
-      request(`${host}/_/users/me`, {
-        json: true,
-        jar: result.jar
-      }, (e, _, body) => {
-        if (e) throw e
-        ok(body.data[0].id)
-        done()
+      return got(`${host}/_/users/me`, {
+        headers: { cookie: result.cookie },
+        json: true
       })
+    }).then(({ body }) => {
+      ok(body.data[0].id)
     })
-  })
+  )
 
-  it('can optionally retrieve an auth token', function (done) {
-    login(args.email, args.password, { host, authToken: true }, (e, result) => {
-      if (e) throw e
+  it('can optionally retrieve an auth token', () =>
+    login(args.email, args.password, { host, authToken: true }).then((result) => {
       eq(result.body.status, 'ok')
       eq(typeof result.token, 'string')
-      done()
     })
-  })
+  )
 
-  it('can retrieve auth tokens for guest users', function (done) {
-    login.guest({ host, authToken: true }, (e, result) => {
-      if (e) throw e
+  it('can retrieve auth tokens for guest users', () =>
+    login.guest({ host, authToken: true }).then((result) => {
       eq(typeof result.token, 'string')
-      done()
     })
-  })
+  )
 
   // https://github.com/goto-bus-stop/plug-login/issues/1
-  it('passes errors nicely instead of blowing up', function (done) {
+  it('passes errors nicely instead of blowing up', () =>
     login.user(args.email, args.password, {
       host,
       _simulateMaintenance: true
-    }, (e, result) => {
-      ok(e)
-      done()
-    })
-  })
+    }).then(fail, ok)
+  )
 })


### PR DESCRIPTION
`got` is much smaller than `request`. plug-login now returns a cookie string instead of a request jar, which should be easier to use with different libraries.